### PR TITLE
set up image search replacement

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,7 +2,6 @@
   "hubot-diagnostics",
   "hubot-help",
   "hubot-heroku-keepalive",
-  "hubot-google-images",
   "hubot-google-translate",
   "hubot-pugme",
   "hubot-maps",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "hubot-maps": "0.0.1",
     "hubot-help": "^0.1.1",
-    "hubot-google-images": "^0.1.2",
     "hubot-diagnostics": "0.0.1",
     "hubot-youtube": "^0.1.2",
     "hubot-pugme": "^0.1.0",

--- a/scripts/google-images-unsafe.coffee
+++ b/scripts/google-images-unsafe.coffee
@@ -6,6 +6,9 @@
 #   hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
 #   hubot mustache me <url> - Adds a mustache to the specified URL.
 #   hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
+#   hubot image unsafe <query> - Safe search is OFF. Use at your own god damn risk.
+#   hubot animate unsafe <query> - Oh God Dammit. Ricky is gonna have a field day.
+
 
 module.exports = (robot) ->
   robot.respond /(image|img)( me) (.*)/i, (msg) ->

--- a/scripts/google-images-unsafe.coffee
+++ b/scripts/google-images-unsafe.coffee
@@ -1,0 +1,59 @@
+# Description:
+#   A way to interact with the Google Images API.
+#
+# Commands:
+#   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
+#   hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
+#   hubot mustache me <url> - Adds a mustache to the specified URL.
+#   hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
+
+module.exports = (robot) ->
+  robot.respond /(image|img)( me) (.*)/i, (msg) ->
+    imageMe msg, msg.match[3], true, (url) ->
+      msg.send url
+
+  robot.respond /(image|img)( unsafe) (.*)/i, (msg) ->
+    imageMe msg, msg.match[3], false, (url) ->
+      msg.send url
+
+  robot.respond /animate( me) (.*)/i, (msg) ->
+    imageMe msg, msg.match[2], true, true, (url) ->
+      msg.send url
+
+  robot.respond /animate( unsafe) (.*)/i, (msg) ->
+    imageMe msg, msg.match[2], false, true, (url) ->
+      msg.send url
+
+  robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
+    type = Math.floor(Math.random() * 6)
+    mustachify = "http://mustachify.me/#{type}?src="
+    imagery = msg.match[1]
+
+    if imagery.match /^https?:\/\//i
+      msg.send "#{mustachify}#{imagery}"
+    else
+      imageMe msg, imagery, false, true, (url) ->
+        msg.send "#{mustachify}#{url}"
+
+imageMe = (msg, query, safe, animated, faces, cb) ->
+  cb = animated if typeof animated == 'function'
+  cb = faces if typeof faces == 'function'
+  q = v: '1.0', rsz: '8', q: query
+  q.safe = if safe then 'active' else 'off'
+  q.imgtype = 'animated' if typeof animated is 'boolean' and animated is true
+  q.imgtype = 'face' if typeof faces is 'boolean' and faces is true
+  msg.http('http://ajax.googleapis.com/ajax/services/search/images')
+    .query(q)
+    .get() (err, res, body) ->
+      images = JSON.parse(body)
+      images = images.responseData?.results
+      if images?.length > 0
+        image = msg.random images
+        cb ensureImageExtension image.unescapedUrl
+
+ensureImageExtension = (url) ->
+  ext = url.split('.').pop()
+  if /(png|jpe?g|gif)/i.test(ext)
+    url
+  else
+    "#{url}#.png"


### PR DESCRIPTION
Now, image and animate can be called in one of two ways:

image/animate me <query>   -->  safe search is on, in the 'active' state

image/animate unsafe <query>   -->  safe search is *off*

use at your own risk.  and probably not during working hours.